### PR TITLE
Add granularity and update output structure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pandas
 requests
+lxml


### PR DESCRIPTION
## Summary
- add `granularity` parameter to `amedas` for specifying time resolution (currently only hourly)
- write daily CSVs under `csv/YYYY/MM/station_YYYYMMDD.csv` and switch to timezone-aware timestamps
- include `lxml` as a dependency to enable HTML parsing

## Testing
- `python -m pip install -r requirements.txt`
- `python jma_scraper.py` *(fails: urlopen error Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6892f905136083208d3546a63dafefc3