### PR TITLE
Add daily AMeDAS scraping script and workflow

### DIFF
--- a/.github/workflows/run-jma-amedas.yml
+++ b/.github/workflows/run-jma-amedas.yml
@@ -1,0 +1,21 @@
+name: Run JMA AMeDAS scraper
+
+on:
+  schedule:
+    - cron: '0 16 * * *' # 01:00 JST
+  workflow_dispatch:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run scraper
+        run: python run_jma_amedas.py

--- a/run_jma_amedas.py
+++ b/run_jma_amedas.py
@@ -1,0 +1,15 @@
+from jma_scraper import jma
+
+
+def main() -> None:
+    scraper = jma()
+    cities = ["札幌", "仙台", "東京", "名古屋", "金沢", "大阪", "広島", "高松", "福岡"]
+
+    for city in cities:
+        scraper.amedas(city, granularity="hourly")
+        print(f"Fetching AMeDAS for {city}")
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_jma_amedas.py` to fetch hourly AMeDAS data for major Japanese cities
- create GitHub Actions workflow scheduled for 01:00 JST to run the scraper daily

## Testing
- `pip install -r requirements.txt`
- `python run_jma_amedas.py` *(data fetches failed with 403 responses in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6893227dc0a883209f4aeb7251722754