### PR TITLE
Fix missing html5lib dependency for AMeDAS scraper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 requests
 lxml
+html5lib


### PR DESCRIPTION
## Summary
- add html5lib to requirements to satisfy pandas.read_html

## Testing
- `pip install -r requirements.txt`
- `python run_jma_amedas.py` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689324bdd4588320afb97d6aa96afa81