### PR TITLE
Enable station disambiguation by prefecture

### DIFF
--- a/run_jma_amedas.py
+++ b/run_jma_amedas.py
@@ -3,7 +3,17 @@ from jma_scraper import jma
 
 def main() -> None:
     scraper = jma()
-    cities = ["札幌", "仙台", "東京", "名古屋", "金沢", "大阪", "広島", "高松", "福岡"]
+    cities = [
+        "札幌",
+        "仙台",
+        "東京",
+        "名古屋",
+        "金沢",
+        "大阪",
+        "広島",
+        "高松(香川県)",
+        "福岡",
+    ]
 
     for city in cities:
         scraper.amedas(city, granularity="hourly")


### PR DESCRIPTION
## Summary
- support specifying station with prefecture suffix to resolve name collisions
- normalize station metadata and clarify station argument documentation
- update example city list to include "高松(香川県)"

## Testing
- `python -m py_compile jma_scraper.py run_jma_amedas.py`
- `python - <<'PY'
from jma_scraper import jma
scraper = jma()
scraper.amedas('高松(香川県)', granularity='hourly')
print('finished')
PY`


------
https://chatgpt.com/codex/tasks/task_e_689327cfe624832098fcd28964397c94