### PR TITLE
Log time range in JST

### DIFF
--- a/jma_scraper.py
+++ b/jma_scraper.py
@@ -6,7 +6,8 @@ import pandas as pd
 import requests
 
 
-JST = timezone(timedelta(hours=9))
+# Explicitly name the timezone so log output shows "JST"
+JST = timezone(timedelta(hours=9), "JST")
 
 
 class jma:
@@ -104,6 +105,13 @@ class jma:
 
         end = end or datetime.now(JST)
         start = start or (end - timedelta(days=1))
+
+        # Show the resolved time range in logs to verify JST handling
+        print(
+            f"Fetching AMeDAS for {station} from "
+            f"{start.astimezone(JST).strftime('%Y-%m-%d %H:%M:%S %Z')} to "
+            f"{end.astimezone(JST).strftime('%Y-%m-%d %H:%M:%S %Z')}"
+        )
 
         if granularity == "all":
             dfs = []


### PR DESCRIPTION
## Summary
- Name the JST timezone so log messages show the timezone name
- Print the resolved start/end times in JST when fetching AMeDAS data

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile jma_scraper.py run_jma_amedas.py`
- `python run_jma_amedas.py` *(fails to fetch data: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68932f1d971483209c59397528313bc8