### PR TITLE
Default AMeDAS scraping to previous day

### DIFF
--- a/jma_scraper.py
+++ b/jma_scraper.py
@@ -84,8 +84,8 @@ class jma:
         start: datetime, optional
             Start of the interval. Defaults to 24 hours before ``end``.
         end: datetime, optional
-            End of the interval. Defaults to the current time in Japan
-            (``datetime.now(JST)``).
+            End of the interval. Defaults to 1 day before the current time in
+            Japan (``datetime.now(JST) - timedelta(days=1)``).
         granularity: str
             Time granularity of the data. ``"hourly"`` downloads data for each
             day between ``start`` and ``end`` and stores them under
@@ -108,7 +108,7 @@ class jma:
                 end.astimezone(JST) if end.tzinfo else end.replace(tzinfo=JST)
             ).date()
         else:
-            end = datetime.now(JST).date()
+            end = (datetime.now(JST) - timedelta(days=1)).date()
 
         if start:
             start = (


### PR DESCRIPTION
## Summary
- default the end date to yesterday so the scraper fetches data from two days ago to yesterday
- document the updated end date behavior

## Testing
- `python -m py_compile jma_scraper.py run_jma_amedas.py`
- `python - <<'PY'
from jma_scraper import jma
try:
    jma().amedas('dummy', granularity='hourly')
except Exception as exc:
    print('Expected error:', exc)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689336d2217c8320b3912a9f60e6d60e